### PR TITLE
Explicitly use mb_string functions where we deal with user-facing str…

### DIFF
--- a/AMQP/MediaDuration.php
+++ b/AMQP/MediaDuration.php
@@ -102,7 +102,7 @@ class AMQP_MediaDuration extends SiteAMQPApplication
             return;
         }
 
-        if (in_array('mp3', explode(',', strtolower($data['format'])))) {
+        if (in_array('mp3', explode(',', mb_strtolower($data['format'])))) {
             // If the file is a MP3 file, ignore the metadata duration and
             // calculate duration based on raw packets.
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
+    "ext-mbstring": "*",
     "psr/log": "^1.0.0",
     "silverorange/site": "^5.0.0"
   },


### PR DESCRIPTION
…ings

This allows us to turn off mb_string.func_overload.